### PR TITLE
Add Armorer Guard to runtime defense resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Note that injection is an attack method, not an attack goal; one can launch an i
             1. PromptGuard: detect direct/indirect prompt injection
         2. Microsoft Prompt Shields [[website](https://learn.microsoft.com/en-us/azure/ai-services/content-safety/concepts/jailbreak-detection)]
             1. detect safety and security of LLM output (e.g., hate, violence, self-harm, direct/indirect prompt injection)
+        3. Armorer Guard: Local Rust scanner and MCP proxy for prompt injection, credential leakage, exfiltration, and dangerous tool-call arguments [[github repo](https://github.com/ArmorerLabs/Armorer-Guard)]
     4. Rule-based guardrails
         1. Nvidia NeMo: DSL for input guardrail [[github repo](https://github.com/NVIDIA-NeMo/NeMo)]
         2. Google safe browsing [[website](https://safebrowsing.google.com/)]


### PR DESCRIPTION
## Summary
- adds Armorer Guard to the System-level Runtime Defense section under model-based input guardrails
- describes it as a local Rust scanner and MCP proxy for prompt injection, credential leakage, exfiltration, and dangerous tool-call arguments

## Why
Armorer Guard fits this section because it is intended for hot-path agent/runtime boundaries rather than only offline evaluation: it can scan task inputs, tool outputs, and MCP `tools/call` arguments locally with structured reasons.

Disclosure: I work on Armorer Labs / Armorer Guard. Happy to move or reword the entry if another subsection fits better.