### PR TITLE
Add PACT: a compliance benchmark for enterprise AI assistants under pressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ A typical agent system is composed of (multiple) LLMs and tools, where LLMs serv
     5. CYBERSECEVAL 2: A Wide-Ranging Cybersecurity Evaluation Suite for Large Language Models [[arxiv'24/04](https://arxiv.org/pdf/2404.13161)]
         1. A section about prompt injection; Two goals: violate application logic (go off-topic)/violate security constraints
     6. A Critical Evaluation of Defenses against Prompt Injection Attacks [[arxiv'25/05](https://arxiv.org/abs/2505.18333)]
+15. PACT: Can Enterprise AI Assistants Be Trusted Under Pressure? [[preprint'26/08](https://www.alphaxiv.org/pdf/2609.pact-enterprise-ai-compliance-testing)]
+    1. 3,364 multi-turn items across 12 regulated domains; tests whether enterprise AI assistants keep following company rules under nine social pressures and user pushback. Leaderboard, dataset, and code: https://trace-ai-labs.github.io/pact/
 
 
 ### Agent system card


### PR DESCRIPTION
Adds one entry under **Agent security survey and benchmarks**.

**PACT: Can Enterprise AI Assistants Be Trusted Under Pressure?** (preprint, 2026) is a compliance benchmark of 3,364 multi-turn items across 12 regulated domains. It tests whether enterprise AI assistants keep following company rules when a deadline, a manager, or a pushy user makes breaking them convenient.

- Paper: https://www.alphaxiv.org/pdf/2609.pact-enterprise-ai-compliance-testing
- Site (leaderboard, results, trial transcripts): https://trace-ai-labs.github.io/pact/
- Dataset: https://huggingface.co/datasets/trace-ai-labs/pact
- Code: https://github.com/trace-ai-labs/pact

No jailbreak strings, just ordinary workplace pressure, which raises violation rates by 65% across 24 models.